### PR TITLE
Add dataLoader utility with PDF parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.21.2"
+        "dotenv": "^16.5.0",
+        "express": "^4.21.2",
+        "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -1817,6 +1819,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3564,6 +3578,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3775,6 +3795,34 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "express": "^4.21.2"
+    "dotenv": "^16.5.0",
+    "express": "^4.21.2",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/scripts/dataLoader.js
+++ b/scripts/dataLoader.js
@@ -1,0 +1,121 @@
+/*
+ * Data Loader Script
+ *
+ * Common Errors & Fixes:
+ * 1. PDF parse error due to password-protected file
+ *    - Fix: Remove password protection or skip the file.
+ * 2. ENOSPC when writing chunks
+ *    - Fix: Ensure sufficient disk space and permissions.
+ * 3. Unexpected token in JSON when reading chunk files
+ *    - Fix: Verify chunk files are complete and not corrupted.
+ */
+
+const fs = require('fs/promises');
+const path = require('path');
+const pdfParse = require('pdf-parse');
+require('dotenv').config();
+
+const PDF_DIR = path.resolve(__dirname, '../resources/pdfs');
+const RAW_DIR = path.resolve(__dirname, '../data/raw_text');
+const CHUNK_DIR = path.resolve(__dirname, '../data/chunks');
+
+async function ensureDir(dirPath) {
+  console.debug('Ensuring directory:', dirPath);
+  try {
+    await fs.mkdir(dirPath, { recursive: true });
+  } catch (err) {
+    console.error('Failed to create directory', dirPath, err);
+    // If dir creation fails, check file system permissions
+    throw err;
+  }
+}
+
+async function extractText(filePath) {
+  try {
+    const buffer = await fs.readFile(filePath);
+    const data = await pdfParse(buffer);
+    return data.text;
+  } catch (err) {
+    console.error('Error parsing PDF', filePath, err);
+    throw err;
+  }
+}
+
+async function writeRawText(fileName, text) {
+  try {
+    const outPath = path.join(RAW_DIR, `${fileName}.txt`);
+    await fs.writeFile(outPath, text);
+    console.debug('Wrote raw text for', fileName);
+  } catch (err) {
+    console.error('Failed to write raw text for', fileName, err);
+    // If write fails, verify RAW_DIR exists
+    throw err;
+  }
+}
+
+function splitIntoChunks(text, fileName, minWords = 200, maxWords = 300) {
+  const words = text.split(/\s+/).filter(Boolean);
+  const chunks = [];
+  let index = 0;
+  while (index < words.length) {
+    const size = Math.min(
+      maxWords,
+      Math.max(minWords, words.length - index)
+    );
+    const chunkWords = words.slice(index, index + size);
+    const chunkText = chunkWords.join(' ');
+    chunks.push({ id: `${fileName}_chunk_${chunks.length}`, text: chunkText });
+    index += size;
+  }
+  return chunks;
+}
+
+async function writeChunks(fileName, chunks) {
+  try {
+    const outPath = path.join(CHUNK_DIR, `${fileName}_chunks.json`);
+    await fs.writeFile(outPath, JSON.stringify(chunks, null, 2));
+    console.debug('Wrote', chunks.length, 'chunks for', fileName);
+  } catch (err) {
+    console.error('Failed to write chunks for', fileName, err);
+    throw err;
+  }
+}
+
+async function processFile(filePath) {
+  const fileName = path.basename(filePath, path.extname(filePath));
+  try {
+    const text = await extractText(filePath);
+    await writeRawText(fileName, text);
+    const chunks = splitIntoChunks(text, fileName);
+    await writeChunks(fileName, chunks);
+  } catch (err) {
+    console.error('Processing failed for', filePath, err);
+  }
+}
+
+async function main() {
+  try {
+    await ensureDir(RAW_DIR);
+    await ensureDir(CHUNK_DIR);
+
+    const files = await fs.readdir(PDF_DIR);
+    const pdfFiles = files.filter(f => f.toLowerCase().endsWith('.pdf'));
+
+    const concurrency = 3;
+    for (let i = 0; i < pdfFiles.length; i += concurrency) {
+      const slice = pdfFiles.slice(i, i + concurrency);
+      await Promise.all(
+        slice.map(name => processFile(path.join(PDF_DIR, name)))
+      );
+    }
+
+    console.debug('All files processed');
+  } catch (err) {
+    console.error('Fatal error in main()', err);
+  }
+}
+
+// For very large PDFs, consider streaming pages instead of full-buffer
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a Node.js script `scripts/dataLoader.js` to parse PDFs and generate text chunks
- install `pdf-parse` and `dotenv` dependencies

## Testing
- `JWT_SECRET=secret JWT_EXPIRES_IN=1h npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849abccb9788328893bf9423fb046d8