### PR TITLE
Add debug logs to backend server startup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -25,6 +25,8 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(buildPath, 'index.html'));
 });
 
+console.debug('Environment PORT =', process.env.PORT);
+console.debug('About to bind on 0.0.0.0:', process.env.PORT);
 app.listen(PORT, HOST, () => {
   console.log(`🚀 Server listening on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- log environment port before starting backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a45ad299083288961d527bb83e889