### PR TITLE
Improve Render debugging logs

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,13 +1,16 @@
 process.on('unhandledRejection', err => console.error('Unhandled Rejection:', err));
 process.on('uncaughtException', err => console.error('Uncaught Exception:', err));
+
 let app;
 try {
+  const fs = require('fs');
   const express = require('express');
   const path = require('path');
   const compression = require('compression');
   const helmet = require('helmet');
   const cors = require('cors');
   const morgan = require('morgan');
+  console.log('==== IMPORTS OK ====');
 
   const HOST = '0.0.0.0';
   const PORT = process.env.PORT || 10000;
@@ -16,12 +19,23 @@ try {
 
   // Core middlewares
   app.use(helmet());
+  console.log('==== MIDDLEWARE OK ====');
   app.use(cors());
+  console.log('==== MIDDLEWARE OK ====');
   app.use(morgan('dev'));
+  console.log('==== MIDDLEWARE OK ====');
   app.use(express.json());
+  console.log('==== MIDDLEWARE OK ====');
   app.use(compression());
+  console.log('==== MIDDLEWARE OK ====');
 
   const buildPath = path.join(__dirname, '../mvp/build');
+  if (!fs.existsSync(buildPath)) {
+    console.error('Build path not found:', buildPath);
+  }
+  if (!fs.existsSync(path.join(buildPath, 'index.html'))) {
+    console.error('index.html not found in build path');
+  }
   console.debug('Serving static files from', buildPath);
   // Enable caching for static assets and gzip compression
   app.use(
@@ -30,18 +44,24 @@ try {
       etag: false,
     })
   );
+  console.log('==== MIDDLEWARE OK ====');
 
   app.get('*', (req, res) => {
     console.debug('Fallback to index.html for', req.originalUrl);
     res.sendFile(path.join(buildPath, 'index.html'));
   });
 
+  console.log('==== ROUTES OK ====');
+
   app.use((err, req, res, next) => {
     console.error('Global error:', err);
     res.status(500).send('Internal Server Error');
   });
 
+  console.log('==== ABOUT TO LISTEN ====');
+  console.log('PORT:', process.env.PORT);
   const server = app.listen(PORT, HOST, () => {
+    console.log('==== BOOT COMPLETED ====');
     console.log(`🚀 Listening on http://${HOST}:${PORT}`);
   });
   server.keepAliveTimeout = 120000; // 120 seconds

--- a/server.js
+++ b/server.js
@@ -1,7 +1,13 @@
+process.on('unhandledRejection', err => console.error('Unhandled Rejection:', err));
+process.on('uncaughtException', err => console.error('Uncaught Exception:', err));
+
 const express = require('express');
+console.log('==== IMPORTS OK ====');
+
 const app = express();
 
 app.use(express.json());
+console.log('==== MIDDLEWARE OK ====');
 
 app.post('/login', (req, res) => {
   // Dummy login route for testing
@@ -13,9 +19,16 @@ app.get('/api/graphs', (req, res) => {
   res.status(200).json({ data: [] });
 });
 
+console.log('==== ROUTES OK ====');
+
 if (require.main === module) {
   const PORT = process.env.PORT || 3000;
-  app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  console.log('==== ABOUT TO LISTEN ====');
+  console.log('PORT:', process.env.PORT);
+  app.listen(PORT, () => {
+    console.log('==== BOOT COMPLETED ====');
+    console.log(`Server running on port ${PORT}`);
+  });
 }
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- log imports, middleware, routes, and startup steps
- add global error handlers
- check for build artifacts before serving static files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a5e0c2c148328b8a20cb5e94f10ac