### PR TITLE
Improve backend boot logging

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,16 +1,23 @@
-process.on('unhandledRejection', err => console.error('Unhandled Rejection:', err));
-process.on('uncaughtException', err => console.error('Uncaught Exception:', err));
+console.log('==== BOOT: Imports started ====');
+process.on('unhandledRejection', err => console.error('==== Unhandled Rejection ====', err));
+process.on('uncaughtException', err => console.error('==== Uncaught Exception ====', err));
 
 let app;
 try {
   const fs = require('fs');
+  console.log('==== BOOT: Imports done ====');
   const express = require('express');
+  console.log('==== BOOT: Imports done ====');
   const path = require('path');
+  console.log('==== BOOT: Imports done ====');
   const compression = require('compression');
+  console.log('==== BOOT: Imports done ====');
   const helmet = require('helmet');
+  console.log('==== BOOT: Imports done ====');
   const cors = require('cors');
+  console.log('==== BOOT: Imports done ====');
   const morgan = require('morgan');
-  console.log('==== IMPORTS OK ====');
+  console.log('==== BOOT: Imports done ====');
 
   const HOST = '0.0.0.0';
   const PORT = process.env.PORT || 10000;
@@ -19,22 +26,22 @@ try {
 
   // Core middlewares
   app.use(helmet());
-  console.log('==== MIDDLEWARE OK ====');
+  console.log('==== BOOT: Middleware OK ====');
   app.use(cors());
-  console.log('==== MIDDLEWARE OK ====');
+  console.log('==== BOOT: Middleware OK ====');
   app.use(morgan('dev'));
-  console.log('==== MIDDLEWARE OK ====');
+  console.log('==== BOOT: Middleware OK ====');
   app.use(express.json());
-  console.log('==== MIDDLEWARE OK ====');
+  console.log('==== BOOT: Middleware OK ====');
   app.use(compression());
-  console.log('==== MIDDLEWARE OK ====');
+  console.log('==== BOOT: Middleware OK ====');
 
   const buildPath = path.join(__dirname, '../mvp/build');
   if (!fs.existsSync(buildPath)) {
-    console.error('Build path not found:', buildPath);
+    console.error('==== ERROR: Build path not found:', buildPath);
   }
   if (!fs.existsSync(path.join(buildPath, 'index.html'))) {
-    console.error('index.html not found in build path');
+    console.error('==== ERROR: index.html not found in build path');
   }
   console.debug('Serving static files from', buildPath);
   // Enable caching for static assets and gzip compression
@@ -44,34 +51,33 @@ try {
       etag: false,
     })
   );
-  console.log('==== MIDDLEWARE OK ====');
+  console.log('==== BOOT: Middleware OK ====');
 
   app.get('*', (req, res) => {
     console.debug('Fallback to index.html for', req.originalUrl);
     res.sendFile(path.join(buildPath, 'index.html'));
   });
 
-  console.log('==== ROUTES OK ====');
+  console.log('==== BOOT: Routes defined ====');
 
   app.use((err, req, res, next) => {
     console.error('Global error:', err);
     res.status(500).send('Internal Server Error');
   });
+  console.log('==== BOOT: Middleware OK ====');
 
-  console.log('==== ABOUT TO LISTEN ====');
-  console.log('PORT:', process.env.PORT);
+  console.log('==== BOOT: About to listen on PORT', PORT, 'HOST', HOST);
   const server = app.listen(PORT, HOST, () => {
-    console.log('==== BOOT COMPLETED ====');
+    console.log('==== BOOT: Listening on', PORT);
+    console.log('==== BOOT: Startup completed ====');
     console.log(`🚀 Listening on http://${HOST}:${PORT}`);
   });
   server.keepAliveTimeout = 120000; // 120 seconds
   server.headersTimeout = 120000; // 120 seconds
   console.debug('keepAliveTimeout and headersTimeout set to 120000');
   // Troubleshoot: if still 502, verify HOST and PORT values in env
-
-  console.log('Boot completed');
 } catch (err) {
-  console.error('Critical boot error:', err);
+  console.error('==== ERROR: Critical boot error:', err);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- add detailed boot logging for Render troubleshooting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a65dbd57c83288c8f5729ddebaa99