### PR TITLE
Add console logging utilities and dashboard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": ["airbnb-base"],
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "ignorePatterns": ["dist/", "build/", "logs/"],
+  "settings": {
+    "import/resolver": {
+      "node": { "extensions": [".js"] }
+    }
+  },
+  "rules": {
+    "no-console": "off",
+    "import/extensions": "off",
+    "import/prefer-default-export": "off",
+    "no-new": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ coverage
 
 # Mac system files
 .DS_Store
+logs/*
+!logs/.gitkeep

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "e2e": "echo \"🚀 Starting Cypress in headless mode ($npm_lifecycle_event)\" && cypress run --headless --browser chrome",
     "e2e:ci": "echo \"🚀 Starting Cypress in headless mode ($npm_lifecycle_event)\" && cypress run --headless --browser electron",
     "install:chrome": "bash scripts/install-chrome.sh",
-    "e2e:chrome": "npm run install:chrome && cypress run --headless --browser chrome"
+    "e2e:chrome": "npm run install:chrome && cypress run --headless --browser chrome",
+    "lint": "eslint .",
+    "format": "prettier --write"
   },
   "keywords": [],
   "author": "",
@@ -43,7 +45,11 @@
     "jest-environment-jsdom": "^30.0.0",
     "supertest": "^6.3.4",
     "xvfb": "^0.4.0",
-    "@types/jest": "^29.5.11"
+    "@types/jest": "^29.5.11",
+    "eslint": "^8.56.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prettier": "^3.0.0"
   },
   "__comment": "Use npm run test to execute all tests"
 }

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,0 +1,39 @@
+/**
+ * Dashboard Component
+ * -------------------------------
+ * Fetches and displays data from jsonplaceholder.
+ * Debug: logs fetch process.
+ * Troubleshoot: displays user-friendly error messages.
+ * Performance optimization: relies on cached responses.
+ */
+import { getData } from '../services/api.js';
+import { logDebug, logError } from '../utils/logger.js';
+
+export default class Dashboard {
+  constructor(root) {
+    this.root = root;
+    this.load();
+  }
+
+  async load() {
+    logDebug('Dashboard: fetching posts');
+    try {
+      const posts = await getData('https://jsonplaceholder.typicode.com/posts');
+      this.render(posts.slice(0, 5));
+    } catch (err) {
+      logError(err.message);
+      this.root.innerHTML = '<p class="error">خطا در دریافت داده‌ها. لطفاً بعداً دوباره تلاش کنید.</p>';
+    }
+  }
+
+  render(items) {
+    this.root.innerHTML = '<h2>Posts</h2>';
+    const ul = document.createElement('ul');
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      li.textContent = item.title;
+      ul.appendChild(li);
+    });
+    this.root.appendChild(ul);
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,13 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self' https://jsonplaceholder.typicode.com;"
+    />
     <title>Sample Web Project</title>
-    <link rel="stylesheet" href="../styles/main.css">
-</head>
-<body>
+    <link rel="stylesheet" href="../styles/main.css" />
+  </head>
+  <body>
     <h1>Welcome to the Sample Web Project</h1>
-    <script src="app.js"></script>
-</body>
+    <div id="app"></div>
+    <script type="module" src="main.js"></script>
+  </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,16 @@
+/**
+ * Main entry
+ * -------------------------------
+ * Debug: sets up global console logging.
+ * Troubleshoot: ensures Dashboard mounts after DOM is ready.
+ * Performance optimization: minimal DOM queries.
+ */
+import Dashboard from './components/Dashboard.js';
+import { setupConsoleLogging, logDebug } from './utils/logger.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupConsoleLogging();
+  logDebug('Main: DOMContentLoaded');
+  const root = document.getElementById('app');
+  if (root) new Dashboard(root);
+});

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,26 @@
+/**
+ * API Service
+ * -------------------------------
+ * Debug: Uses AbortController to handle request timeouts.
+ * Troubleshoot: Catches network errors and provides fallback from cache.
+ * Performance optimization: caches successful responses in-memory.
+ */
+const cache = new Map();
+
+export async function getData(url, { timeout = 5000 } = {}) {
+  if (cache.has(url)) return cache.get(url);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    cache.set(url, data);
+    return data;
+  } catch (err) {
+    clearTimeout(timer);
+    if (cache.has(url)) return cache.get(url);
+    throw err;
+  }
+}

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,38 @@
+/**
+ * Logger Utility
+ * -------------------------------
+ * Debug: Writes timestamped logs for troubleshooting.
+ * Troubleshoot: Handles file write errors gracefully.
+ * Performance optimization: minimal synchronous operations.
+ */
+import { appendFile } from 'fs/promises';
+import path from 'path';
+
+const logFile = path.join(process.cwd(), 'logs', 'debug.log');
+
+function formatMessage(level, message) {
+  const timestamp = new Date().toISOString();
+  return `[${timestamp}] ${level.toUpperCase()}: ${message}\n`;
+}
+
+export async function writeLog(level, message) {
+  try {
+    await appendFile(logFile, formatMessage(level, message));
+  } catch (err) {
+    // Troubleshoot: log file permissions or missing directory
+    console.error('Log write failed', err);
+  }
+}
+
+export const logDebug = (message) => writeLog('debug', message);
+export const logError = (message) => writeLog('error', message);
+
+export function setupConsoleLogging() {
+  ['log', 'error', 'warn'].forEach((method) => {
+    const original = console[method];
+    console[method] = (...args) => {
+      writeLog(method, args.join(' '));
+      original.apply(console, args);
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- log to `logs/debug.log` with custom logger utility
- add API service with fetch caching and timeout support
- create `Dashboard` component and main entry
- update CSP in `index.html`
- configure ESLint (Airbnb) and Prettier

## Testing
- `npx eslint src/main.js src/components/Dashboard.js src/services/api.js src/utils/logger.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a6e9c82348328be338757dffd988b