### PR TITLE
Implement console debugging utilities

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; connect-src 'self' https://jsonplaceholder.typicode.com;"
+    />
+    <title>Sample Web Project</title>
+    <link rel="stylesheet" href="../styles/main.css" />
+  </head>
+  <body>
+    <h1>Welcome to the Sample Web Project</h1>
+    <div id="app"></div>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -22,7 +22,8 @@ export default class Dashboard {
       this.render(posts.slice(0, 5));
     } catch (err) {
       logError(err.message);
-      this.root.innerHTML = '<p class="error">خطا در دریافت داده‌ها. لطفاً بعداً دوباره تلاش کنید.</p>';
+      this.root.innerHTML =
+        '<p class="error">خطا در دریافت داده‌ها. لطفاً بعداً دوباره تلاش کنید.</p>';
     }
   }
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -8,11 +8,19 @@
 import { appendFile } from 'fs/promises';
 import path from 'path';
 
+function getCallerLocation() {
+  const err = new Error();
+  const stackLine = err.stack?.split('\n')[3] || '';
+  const match = stackLine.match(/\(?([^():]+):(\d+):(\d+)\)?/);
+  return match ? `${match[1]}:${match[2]}` : 'unknown';
+}
+
 const logFile = path.join(process.cwd(), 'logs', 'debug.log');
 
 function formatMessage(level, message) {
   const timestamp = new Date().toISOString();
-  return `[${timestamp}] ${level.toUpperCase()}: ${message}\n`;
+  const location = getCallerLocation();
+  return `[${timestamp}] ${level.toUpperCase()} (${location}): ${message}\n`;
 }
 
 export async function writeLog(level, message) {


### PR DESCRIPTION
## Summary
- enhance logger to include caller location
- add fetchWithTimeout and localStorage caching
- prettify Dashboard component
- expose public/index.html for easier serving

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7098fe408328920062b6f7e5ac1d