### PR TITLE
Improve fetch error handling

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -4,9 +4,18 @@ import { Chart } from 'chart.js/auto'
 
 // helper to fetch JSON with error handling
 async function fetchJson(url) {
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
-  return res.json()
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
+    return res.json()
+  } catch (err) {
+    console.error('Fetch error:', err)
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML =
+        '<div>دریافت اطلاعات با خطا مواجه شد. لطفا بعدا تلاش کنید.</div>'
+    }
+    throw err
+  }
 }
 
 let barChart

--- a/js/graph.js
+++ b/js/graph.js
@@ -4,9 +4,18 @@ import * as d3 from 'd3'
 
 // helper to fetch JSON with error handling
 async function fetchJson(url) {
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
-  return res.json()
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
+    return res.json()
+  } catch (err) {
+    console.error('Fetch error:', err)
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML =
+        '<div>دریافت اطلاعات با خطا مواجه شد. لطفا بعدا تلاش کنید.</div>'
+    }
+    throw err
+  }
 }
 
 // main export

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -31,6 +31,11 @@ export async function fetchWithTimeout(url, options = {}, timeout = 5000) {
     return res;
   } catch (err) {
     clearTimeout(timer);
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML =
+        '<div>دریافت اطلاعات با خطا مواجه شد. لطفا بعدا تلاش کنید.</div>';
+    }
+    console.error('Fetch error:', err);
     throw err;
   }
 }
@@ -46,6 +51,11 @@ export async function getData(url, { timeout = 5000 } = {}) {
     return data;
   } catch (err) {
     if (cached) return cached;
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML =
+        '<div>دریافت اطلاعات با خطا مواجه شد. لطفا بعدا تلاش کنید.</div>';
+    }
+    console.error('Fetch error:', err);
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- show user-facing message and console log when fetch fails in `src/services/api.js`
- handle API errors in `js/dashboard.js` and `js/graph.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a72818d408328b240dd39a60ffcef