### PR TITLE
Add robust logger with file output and tests

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -21,7 +21,7 @@ export default class Dashboard {
       const posts = await getData('https://jsonplaceholder.typicode.com/posts');
       this.render(posts.slice(0, 5));
     } catch (err) {
-      logError(err.message);
+      logError(err, 'Dashboard:load');
       this.root.innerHTML =
         '<p class="error">خطا در دریافت داده‌ها. لطفاً بعداً دوباره تلاش کنید.</p>';
     }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,6 +5,7 @@
  * Troubleshoot: Catches network errors and provides fallback from cache.
  * Performance optimization: caches successful responses in-memory.
  */
+import { logError } from '../utils/logger.js';
 const cache = new Map();
 
 function getFromStorage(key) {
@@ -31,6 +32,7 @@ export async function fetchWithTimeout(url, options = {}, timeout = 5000) {
     return res;
   } catch (err) {
     clearTimeout(timer);
+    logError(err, 'api.js:fetchWithTimeout');
     throw err;
   }
 }
@@ -45,6 +47,7 @@ export async function getData(url, { timeout = 5000 } = {}) {
     saveToStorage(url, data);
     return data;
   } catch (err) {
+    logError(err, 'api.js:getData');
     if (cached) return cached;
     throw err;
   }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -5,7 +5,7 @@
  * Troubleshoot: Handles file write errors gracefully.
  * Performance optimization: minimal synchronous operations.
  */
-import { appendFile } from 'fs/promises';
+import { appendFile, mkdir } from 'fs/promises';
 import path from 'path';
 
 function getCallerLocation() {
@@ -15,25 +15,48 @@ function getCallerLocation() {
   return match ? `${match[1]}:${match[2]}` : 'unknown';
 }
 
+function getErrorLocation(error) {
+  const line = error?.stack?.split('\n')[1] || '';
+  const match = line.match(/\(?([^():]+):(\d+):(\d+)\)?/);
+  return match ? `${match[1]}:${match[2]}` : null;
+}
+
 const logFile = path.join(process.cwd(), 'logs', 'debug.log');
 
-function formatMessage(level, message) {
+async function ensureLogDir() {
+  try {
+    await mkdir(path.dirname(logFile), { recursive: true });
+  } catch (err) {
+    // ignore directory creation errors
+  }
+}
+
+function formatMessage(level, message, location = getCallerLocation()) {
   const timestamp = new Date().toISOString();
-  const location = getCallerLocation();
   return `[${timestamp}] ${level.toUpperCase()} (${location}): ${message}\n`;
 }
 
-export async function writeLog(level, message) {
+export async function writeLog(level, message, location) {
   try {
-    await appendFile(logFile, formatMessage(level, message));
+    await ensureLogDir();
+    await appendFile(logFile, formatMessage(level, message, location));
   } catch (err) {
     // Troubleshoot: log file permissions or missing directory
     console.error('Log write failed', err);
   }
 }
 
-export const logDebug = (message) => writeLog('debug', message);
-export const logError = (message) => writeLog('error', message);
+export const logDebug = (message, location) => {
+  console.debug(formatMessage('debug', message, location).trim());
+  return writeLog('debug', message, location);
+};
+
+export const logError = (error, location) => {
+  const msg = error instanceof Error ? error.message : String(error);
+  const loc = location || getErrorLocation(error) || getCallerLocation();
+  console.error(formatMessage('error', msg, loc).trim());
+  return writeLog('error', msg, loc);
+};
 
 export function setupConsoleLogging() {
   ['log', 'error', 'warn'].forEach((method) => {

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { logError } from '../../src/utils/logger.js';
+
+describe('logger utility', () => {
+  const logPath = path.join(process.cwd(), 'logs', 'debug.log');
+
+  beforeEach(() => {
+    if (fs.existsSync(logPath)) {
+      fs.unlinkSync(logPath);
+    }
+  });
+
+  it('writes error message to log file', async () => {
+    const err = new Error('test failure');
+    await logError(err, 'logger.test');
+    const data = fs.readFileSync(logPath, 'utf8');
+    expect(data).toMatch('test failure');
+    expect(data).toMatch('logger.test');
+  });
+});


### PR DESCRIPTION
## Summary
- enhance `src/utils/logger.js` to log errors with timestamp and location to console and `logs/debug.log`
- update `Dashboard` and API service to use the new `logError`
- add unit test ensuring errors are written to the log file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a732102808328b49384a332741bc8