### PR TITLE
Improve fetch error handling

### DIFF
--- a/mvp/src/components/DashboardPage.jsx
+++ b/mvp/src/components/DashboardPage.jsx
@@ -20,6 +20,10 @@ export default function DashboardPage() {
         setUser(data)
       } catch (err) {
         console.error(err)
+        if (typeof document !== 'undefined') {
+          document.body.innerHTML =
+            '<div>ارتباط با سرور برقرار نشد. لطفا بعدا تلاش کنید.</div>'
+        }
       }
     }
     load()

--- a/mvp/src/utils/api.js
+++ b/mvp/src/utils/api.js
@@ -1,11 +1,22 @@
 export async function fetchUser(token) {
   console.debug('API fetchUser start')
   const headers = token ? { Authorization: `Bearer ${token}` } : {}
-  const res = await fetch('https://jsonplaceholder.typicode.com/users/1', { headers })
-  console.debug('API fetchUser end')
-  if (!res.ok) {
-    throw new Error('Failed to fetch user')
+  try {
+    const res = await fetch('https://jsonplaceholder.typicode.com/users/1', {
+      headers
+    })
+    console.debug('API fetchUser end')
+    if (!res.ok) {
+      throw new Error('Network response was not ok')
+    }
+    return res.json()
+  } catch (err) {
+    console.error('Fetch error:', err)
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML =
+        '<div>ارتباط با سرور برقرار نشد. لطفا بعدا تلاش کنید.</div>'
+    }
+    throw err
   }
-  return res.json()
 }
 // If data doesn’t load, verify API URL in api.js

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -22,6 +22,11 @@ export default class Dashboard {
       const posts = await getData('https://jsonplaceholder.typicode.com/posts');
       this.render(posts.slice(0, 5));
     } catch (err) {
+      logError(err, 'Dashboard:load');
+      if (this.root) {
+        this.root.innerHTML =
+          '<div>ارتباط با سرور برقرار نشد. لطفا بعدا تلاش کنید.</div>';
+      }
     }
   }
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -33,6 +33,11 @@ export async function fetchWithTimeout(url, options = {}, timeout = 5000) {
     return res;
   } catch (err) {
     clearTimeout(timer);
+    if (typeof document !== 'undefined') {
+      document.body.innerHTML =
+        '<div>ارتباط با سرور برقرار نشد. لطفا بعدا تلاش کنید.</div>';
+    }
+    console.error('Fetch error:', err);
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- add error handling when fetching posts in `Dashboard.js`
- handle fetch errors for `fetchUser` and Dashboard page
- show user-friendly messages for network failures
- handle errors in `fetchWithTimeout`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa9508e288328b30be6c1f24082e5