### PR TITLE
Fix module config for semantic-release

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,0 +1,10 @@
+// semantic-release configuration using CommonJS to avoid ESM require errors
+module.exports = {
+  branches: ['main'],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+    '@semantic-release/github',
+  ],
+};

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ npm run build -- --minify
 
 ## License
 MIT License
+
+## Release
+Run `npm run release` to publish using semantic-release.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format": "prettier --write \"public/**/*.html\" \"mvp/**/*.html\" \"src/**/*.{js,jsx}\"",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "release": "semantic-release"
   },
   "keywords": [],
   "author": "",
@@ -56,5 +57,6 @@
     "prettier": "^2.8.8",
     "vite": "^6.3.5"
   },
-  "__comment": "Use npm run test to execute all tests"
+  "__comment": "Use npm run test to execute all tests",
+  "comment": "added release script for semantic-release"
 }


### PR DESCRIPTION
## Summary
- add CommonJS `.releaserc.cjs`
- add `release` script in `package.json`
- document release command in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b17cbdd3c8328ac84960c327cf78a