### PR TITLE
Add deployment config for CSP and SPA routing

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,0 +1,10 @@
+{
+  "headers": {
+    "/**": {
+      "Content-Security-Policy": "default-src 'self'; connect-src 'self' https://jsonplaceholder.typicode.com;"
+    }
+  },
+  "rewrites": [
+    { "source": "**", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `static.json` in repo root to define CSP headers and SPA rewrites

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@humanwhocodes/config-array')*

------
https://chatgpt.com/codex/tasks/task_e_684b17b6c82c83289c5e8c7f2d901ce6