### PR TITLE
Fix CSP settings with helmet

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -25,7 +25,19 @@ try {
   app = express();
 
   // Core middlewares
-  app.use(helmet());
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          connectSrc: ["'self'", 'https://jsonplaceholder.typicode.com'],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          imgSrc: ["'self'", 'data:'],
+        },
+      },
+    })
+  );
   console.log('==== BOOT: Middleware OK ====');
   app.use(cors());
   console.log('==== BOOT: Middleware OK ====');

--- a/server.js
+++ b/server.js
@@ -10,18 +10,21 @@ process.on('uncaughtException', (err) => {
 const express = require('express');
 const path = require('path');
 const helmet = require('helmet');
-const path = require('path');
 
 console.log('==== IMPORTS OK ====');
 
 const app = express();
 
+// Apply CSP headers allowing fetches to jsonplaceholder
 app.use(
   helmet({
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
         connectSrc: ["'self'", 'https://jsonplaceholder.typicode.com'],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:'],
       },
     },
   })


### PR DESCRIPTION
## Summary
- configure Helmet CSP to allow JSONPlaceholder as a connect source
- apply the same policy in the backend server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d3113e6148328920f4d4b4f88bc1a