### PR TITLE
Add Jest scripts and developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ npm run build -- --minify
 - CI mode: `npm run ci:test`
 - In CI, use `--runInBand` to avoid concurrency issues
 - Keep tests fast and isolated; mock external services
+- If `jest` is not found, run `npm install --save-dev jest`
 
 ### Running Cypress E2E Tests
 - **Locally with Chrome**:

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -11,5 +12,9 @@
     "cors": "^2.8.5",
     "morgan": "^1.10.0",
     "compression": "^1.7.4"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -1,0 +1,64 @@
+# Developer Guide
+
+This guide explains how to install dependencies, run unit tests with Jest, and troubleshoot common issues.
+
+## Prerequisites
+- **Node.js** 14 or newer
+- **npm** (comes with Node.js)
+- **Git** for cloning the repository
+
+## Installation
+1. Clone the repository and install dependencies:
+   ```bash
+   git clone <repository-url>
+   cd <project-root>
+   npm install
+   ```
+2. If the environment cannot reach the npm registry, consider:
+   - Setting up an npm proxy or mirror (`npm config set registry <url>`).
+   - Using a pre-populated cache (`npm ci --offline`).
+   - Creating a separate build stage in Docker to run `npm ci` and copying the resulting `node_modules` directory into the final image.
+
+## Running Tests
+- **All tests**:
+  ```bash
+  npm test
+  ```
+- **Watch mode**:
+  ```bash
+  npm run test:watch
+  ```
+- **Coverage report**:
+  ```bash
+  npm run test:coverage
+  ```
+- **CI mode** (serial execution):
+  ```bash
+  npm run ci:test
+  ```
+
+### Installing Jest
+If you see `jest: command not found`, install Jest as a development dependency:
+```bash
+npm install --save-dev jest
+```
+Running `npm install` at the project root also installs Jest and other required packages.
+
+## Troubleshooting Tests
+1. **Tests fail with `Cannot find module`**
+   - Ensure `node_modules` exists and run `npm install` if not.
+2. **Timeouts or hanging tests**
+   - Increase Jest timeout using `jest.setTimeout` or check async code for unhandled promises.
+3. **Network restrictions** during install
+   - Use the caching or Docker strategies mentioned above.
+
+## Project Structure (Testing)
+```
+project-root
+├── tests/              # Root unit tests
+│   └── unit/
+├── backend/tests/      # Backend tests
+└── developer_guide.md
+```
+
+Running `npm test` from the project root executes all Jest tests under `tests` and `backend/tests`.

--- a/mvp/package.json
+++ b/mvp/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build --minify",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -28,6 +29,7 @@
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.9",
     "tailwindcss-cli": "^0.1.2",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add test script and dev deps to backend and mvp packages
- document how to install and run Jest
- include CI/network tips in new developer guide
- mention installing Jest in README troubleshooting

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d37f055c4832898b563f5ce8f3f3c