### PR TITLE
Add Cypress e2e tests and docs

### DIFF
--- a/cypress/e2e/app_flow.cy.js
+++ b/cypress/e2e/app_flow.cy.js
@@ -1,0 +1,53 @@
+describe('Application flow', () => {
+  const api = 'http://localhost:10000';
+
+  it('logs in and receives a token', () => {
+    cy.request('POST', `${api}/login`, {
+      email: 'user@example.com',
+      password: 'secret'
+    }).its('body').should('have.property', 'token').then((token) => {
+      expect(token).to.exist;
+    });
+  });
+
+  it('fetches dashboard data with auth token', () => {
+    cy.request('POST', `${api}/login`, {
+      email: 'user@example.com',
+      password: 'secret'
+    }).then((res) => {
+      const token = res.body.token;
+      cy.request({
+        url: `${api}/api/dashboard/data.json`,
+        headers: { Authorization: `Bearer ${token}` }
+      }).its('status').should('eq', 200);
+    });
+  });
+
+  it('uploads a file', () => {
+    cy.request('POST', `${api}/login`, {
+      email: 'user@example.com',
+      password: 'secret'
+    }).then((res) => {
+      const token = res.body.token;
+      cy.fixture('sample.json', 'binary')
+        .then(Cypress.Blob.binaryStringToBlob)
+        .then((fileContent) => {
+          cy.request({
+            method: 'POST',
+            url: `${api}/api/upload`,
+            headers: {
+              Authorization: `Bearer ${token}`
+            },
+            form: true,
+            body: {
+              file: {
+                fileContent,
+                fileName: 'sample.json',
+                mimeType: 'application/json'
+              }
+            }
+          }).its('status').should('eq', 200);
+        });
+    });
+  });
+});

--- a/cypress/fixtures/sample.json
+++ b/cypress/fixtures/sample.json
@@ -1,0 +1,1 @@
+{"hello": "world"}

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -37,6 +37,16 @@ This guide explains how to install dependencies, run unit tests with Jest, and t
   npm run ci:test
   ```
 
+### Running Cypress E2E Tests
+Run headless tests:
+```bash
+npm run e2e
+```
+Open Cypress in a browser:
+```bash
+npx cypress open
+```
+
 ### Installing Jest
 If you see `jest: command not found`, install Jest as a development dependency:
 ```bash

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -45,6 +45,16 @@ Generate coverage:
 npm run test:coverage
 ```
 
+### Running Cypress E2E Tests
+Headless mode:
+```bash
+npm run e2e
+```
+Run with a browser:
+```bash
+npx cypress open
+```
+
 ## Debugging
 Enable verbose logging:
 ```bash


### PR DESCRIPTION
## Summary
- add e2e test covering login, dashboard, and file upload
- document Cypress usage in headless mode and in a browser

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7ca927508328acee12ec4268b08f