### PR TITLE
Update docs and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ git clone <repository-url>
 cd <project-root>
 npm install
 ```
+Copy `.env.example` to `.env` and adjust database credentials if needed.
 
 ## Project Structure
 ```
@@ -84,12 +85,32 @@ MIT License
 ## Release
 Run `npm run release` to publish using semantic-release.
 
-## Docker Usage
-To run the backend together with PostgreSQL and MongoDB use Docker Compose:
+## اجرای Docker Compose
+برای اجرا کردن تمام سرویس‌ها به صورت محلی از Docker Compose استفاده کنید:
 ```bash
 docker-compose up --build
 ```
-The React frontend image can be built separately:
-```bash
-docker build -t my-frontend ./mvp
+کانتینر Node روی پورت `10000` در دسترس خواهد بود و پایگاه‌های داده PostgreSQL و MongoDB نیز اجرا می‌شوند.
+
+## دسترسی به API
+پس از راه‌اندازی، آدرس پایه API عبارت است از:
+```
+http://localhost:10000
+```
+مسیرهای مهم:
+- `POST /register` – ثبت‌نام کاربر
+- `POST /login` – دریافت توکن
+- `GET /admin-only` – فقط برای نقش admin
+- `GET /api/graphs` – بازیابی گراف
+- `POST /api/upload` – آپلود فایل
+- `GET /api/dashboard/data.json` – داده‌های داشبورد
+
+## مسیرهای اصلی پروژه
+```
+project-root
+├── backend/      # کد Node و API
+├── mvp/          # کد React
+├── data/         # داده‌های نمونه
+├── docs/         # مستندات
+└── scripts/      # اسکریپت‌های کمکی
 ```

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -77,3 +77,21 @@ Running `npm test` from the project root executes all Jest tests under `tests` a
 The Express server serves the React dashboard from `mvp/build`. The `npm start` command builds the React app first (via `prestart`) and then launches the server.
 
 After starting, verify the dashboard loads at `http://localhost:3000` and check `GET /api/dashboard/data.json` for sample data.
+
+## Docker Compose for Development
+Run all services together:
+```bash
+docker-compose up --build
+```
+This command launches the Node API on port `10000` and starts PostgreSQL and MongoDB containers. Update `.env` to match the credentials defined in `docker-compose.yml`.
+
+## Hot Reload & Debugging
+During backend development you can use `nodemon` for automatic restarts:
+```bash
+npx nodemon backend/server.js
+```
+The React frontend supports hot reload using:
+```bash
+npm run dev
+```
+Application logs are written under the `logs/` directory when running via Docker Compose.

--- a/docs/api_spec.md
+++ b/docs/api_spec.md
@@ -1,5 +1,38 @@
 # API Reference
 
+## /register (POST)
+**Endpoint:** `POST /register`
+
+**Description:** Create a new user account.
+
+### Request
+- Headers:
+  - `Content-Type: application/json`
+- Body parameters:
+  - `email` (string, required)
+  - `password` (string, required)
+  - `roles` (array of strings, optional)
+- Example:
+```json
+{
+  "email": "new@example.com",
+  "password": "secret",
+  "roles": ["admin"]
+}
+```
+
+### Response
+- Success: `201 Created`
+```json
+{
+  "id": 1,
+  "email": "new@example.com"
+}
+```
+- Error: `409 Conflict` "User exists"
+
+**Debug:** Ensure PostgreSQL is running and reachable.
+
 ## /login (POST)
 **Endpoint:** `POST /login`
 
@@ -32,6 +65,27 @@
 **Debug:** Check logs if a 500 occurs.
 
 **Troubleshoot:** If you receive 401, verify `JWT_SECRET` and token payload.
+
+## /admin-only (GET)
+**Endpoint:** `GET /admin-only`
+
+**Description:** Protected test route requiring the `admin` role.
+
+### Request
+- Headers:
+  - `Authorization: Bearer <token>`
+- No parameters.
+
+### Response
+- Success: `200 OK`
+```json
+{
+  "message": "Welcome, admin!"
+}
+```
+- Errors: `401 Unauthorized`, `403 Forbidden`
+
+**Debug:** Ensure the user has the `admin` role in PostgreSQL.
 
 ## /api/graphs (GET)
 **Endpoint:** `GET /api/graphs`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,11 +5,14 @@ This system provides a simple full-stack template using Node.js, Express, and Re
 
 ## High-Level Diagram
 ```mermaid
-graph LR
-  FE[React SPA] --> BE[Express API]
-  BE --> PG[(PostgreSQL)]
-  BE --> MG[(MongoDB)]
-  BE --> Docs[docs/]
+graph TD
+  User[Browser] --> SPA[React SPA]
+  SPA --> API[Express API]
+  subgraph Services
+    API --> Postgres[(PostgreSQL)]
+    API --> Mongo[(MongoDB)]
+  end
+  API --> Docs[Docs]
 ```
 <!-- If this diagram doesn’t render, ensure Mermaid support in your Markdown viewer -->
 


### PR DESCRIPTION
## Summary
- expand installation steps in README
- document docker compose usage and API routes
- list project directories
- document additional API endpoints
- redesign architecture diagram
- expand development guide with docker and debugging tips

## Testing
- `npm test` *(fails: Cannot parse backend/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d80fa1c748328bd0347026ee80acf