### PR TITLE
Fix backend package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "backend",
   "version": "1.0.0",
+  "description": "Express backend server",
   "main": "server.js",
   "scripts": {
     "prestart": "npm install",
@@ -9,15 +10,24 @@
     "build": "echo \"no build step\"",
     "test": "jest --runInBand"
   },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "compression": "^1.7.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.5.0",
     "express": "^4.18.2",
     "helmet": "^6.0.1",
-    "cors": "^2.8.5",
-    "morgan": "^1.10.0",
-    "compression": "^1.7.4",
     "jsonwebtoken": "^9.0.2",
-    "bcryptjs": "^2.4.3",
+    "mongoose": "^7.6.1",
+    "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
+    "pg": "^8.11.3",
+    "pg-mem": "^2.9.1",
+    "sequelize": "^6.37.1"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- clean up `backend/package.json`
- ensure JSON is valid and add missing dependency versions

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('backend/package.json','utf8')); console.log('JSON valid')"`
- `npm install --prefix backend --package-lock-only`

------
https://chatgpt.com/codex/tasks/task_e_684d83ff569483289fd588e287e40214